### PR TITLE
Requiring crack >= 0.3.2 to avoid parameter parsing vulnerability

### DIFF
--- a/ruby-fogbugz.gemspec
+++ b/ruby-fogbugz.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "ruby-fogbugz"
 
   # s.add_dependency('typhoeus')
-  s.add_dependency('crack')
+  s.add_dependency('crack', '>= 0.3.2')
 
   s.add_development_dependency('minitest')
   s.add_development_dependency('mocha')


### PR DESCRIPTION
Versions of crack prior to 0.3.2 are vulnerable to the Rails parameter parsing vulnerability.

(https://support.cloud.engineyard.com/entries/22915701-january-14-2013-security-vulnerabilities-httparty-extlib-crack-nori-update-these-gems-immediately)
