### PR TITLE
require 'crack/util' in the cracker adapter

### DIFF
--- a/lib/ruby_fogbugz/adapters/xml/cracker.rb
+++ b/lib/ruby_fogbugz/adapters/xml/cracker.rb
@@ -1,3 +1,4 @@
+require 'crack/util'
 require 'crack/xml'
 
 module Fogbugz

--- a/test/adapters/xml/crack_test.rb
+++ b/test/adapters/xml/crack_test.rb
@@ -12,4 +12,15 @@ class Cracker < FogTest
 
     assert_equal({"version" => "2"}, Fogbugz::Adapter::XML::Cracker.parse(XML))
   end
+
+  # Sometimes Fogbugz returns responses like this
+  test 'should return nil when the response is not valid' do
+    XML = <<-xml
+      <html><head><title>Object moved</title></head><body>
+      <h2>Object moved to <a href="http://example.fogbugz.com:84/internalError.asp?aspxerrorpath=/api.asp">here</a>.</h2>
+      </body></html>
+    xml
+
+    assert_equal(nil, Fogbugz::Adapter::XML::Cracker.parse(XML))
+  end
 end


### PR DESCRIPTION
The `Crack::XML` uses `Crack::Util` https://github.com/jnunemaker/crack/blob/v0.4.2/lib/crack/xml.rb#L181.
Normally this would be required when someone does `require 'crack'` but `Fogbugz::Adapter::XML::Cracker` only has `require 'crack/xml'`.

This pull request has a change where I add a test that fails without `Crack::Util` (based on output I actually got from hosted FogBugz), and then the fix to make the tests pass.