### PR TITLE
Fix to PR #11 so it will work with Ruby 1.9.3

### DIFF
--- a/lib/ruby_fogbugz/adapters/http/net_http.rb
+++ b/lib/ruby_fogbugz/adapters/http/net_http.rb
@@ -12,15 +12,18 @@ module Fogbugz
         end
 
         def request(action, options)
-          # Convert the hash key/values to key=value&key2=value2 strings - CGI escaping along the way
-          options_string = options[:params].map{ |k, v| "#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}"}.join('&')
-          
-          url_string = "#{@root_url}/api.asp?cmd=#{action}&#{options_string}"
-          url = URI.parse(url_string)
-          
-          request = Net::HTTP::Get.new(url_string, {"Content-Type"=>"text/xml"})
-          
-          http = Net::HTTP.new(url.host, url.port)
+          uri = URI("#{@root_url}/api.asp")
+
+          params = {
+            'cmd' => action
+          }
+          params.merge!(options[:params])
+
+          # build up the form request
+          request = Net::HTTP::Post.new(uri)
+          request.set_form_data(params)
+
+          http = Net::HTTP.new(uri.host, uri.port)
           http.use_ssl = @root_url.start_with? 'https'
           
           response = http.start {|http| http.request(request) }

--- a/lib/ruby_fogbugz/adapters/http/net_http.rb
+++ b/lib/ruby_fogbugz/adapters/http/net_http.rb
@@ -20,7 +20,7 @@ module Fogbugz
           params.merge!(options[:params])
 
           # build up the form request
-          request = Net::HTTP::Post.new(uri)
+          request = Net::HTTP::Post.new(uri.request_uri)
           request.set_form_data(params)
 
           http = Net::HTTP.new(uri.host, uri.port)


### PR DESCRIPTION
This change is a small fix to @gamepoet's PR #11 so that it works with Ruby 1.9.3. In Ruby 2 `Net::HTTP::Post.new` can take a uri or a path (String), but in Ruby 1.9.3 it needs to be a String. Otherwise you get a NoMethodError for URI#empty? on this line: https://github.com/ruby/ruby/blob/v1_9_3_551/lib/net/http.rb#L1861

In Ruby 2.x net/http has changed a lot and it can deal with a URI being passed into the constructor for requests. Here it's calling URI#request_uri to get the path when the arg is a URI. https://github.com/ruby/ruby/blob/v2_0_0_0/lib/net/http/generic_request.rb#L19

