### PR TITLE
Support case attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,16 @@ Run the script, and initialize with the returned token:
 fogbugz = Fogbugz::Interface.new(:token => "some token to use from now on", :uri => 'https://company.fogbugz.com') # remember to use https!
 ```
 
+### Attachments
+
+This library supports multipart file uploads to include attachments in your API request. A multipart request body is created (using the [multipart-post][mpp] gem) if `File1` is found in the command parameters. Files can be attached as follows:
+
+```ruby
+fogbugz.command(:new, sProject: "SomeProject", sArea: "someArea", sTitle: "Case title", File1: UploadIO.new(f, "text/plain", "someFile.rb"))
+```
+
 [fad]:http://fogbugz.stackexchange.com/fogbugz-xml-api
+[mpp]:https://github.com/nicksieger/multipart-post
 
 ## License
 

--- a/lib/ruby_fogbugz/adapters/http/net_http.rb
+++ b/lib/ruby_fogbugz/adapters/http/net_http.rb
@@ -1,5 +1,6 @@
 require 'cgi'
 require 'net/https'
+require 'net/http/post/multipart'
 
 module Fogbugz
   module Adapter
@@ -18,8 +19,12 @@ module Fogbugz
           params.merge!(options[:params])
 
           # build up the form request
-          request = Net::HTTP::Post.new(uri.request_uri)
-          request.set_form_data(params)
+          if params.key? :File1
+            request = Net::HTTP::Post::Multipart.new(uri.request_uri, params)
+          else
+            request = Net::HTTP::Post.new(uri.request_uri)
+            request.set_form_data(params)
+          end
 
           http = Net::HTTP.new(uri.host, uri.port)
           http.use_ssl = @root_url.start_with? 'https'

--- a/lib/ruby_fogbugz/adapters/http/net_http.rb
+++ b/lib/ruby_fogbugz/adapters/http/net_http.rb
@@ -12,19 +12,21 @@ module Fogbugz
           @root_url = options[:uri]
         end
 
+        def build_request(uri, params)
+          return Net::HTTP::Post::Multipart.new(uri.request_uri, params) if params.key? :File1
+
+          request = Net::HTTP::Post.new(uri.request_uri)
+          request.set_form_data(params)
+          request
+        end
+
         def request(action, options)
           uri = URI("#{@root_url}/api.asp")
 
           params = { 'cmd' => action }
           params.merge!(options[:params])
 
-          # build up the form request
-          if params.key? :File1
-            request = Net::HTTP::Post::Multipart.new(uri.request_uri, params)
-          else
-            request = Net::HTTP::Post.new(uri.request_uri)
-            request.set_form_data(params)
-          end
+          request = build_request(uri, params)
 
           http = Net::HTTP.new(uri.host, uri.port)
           http.use_ssl = @root_url.start_with? 'https'

--- a/ruby-fogbugz.gemspec
+++ b/ruby-fogbugz.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = 'ruby-fogbugz'
 
   s.add_dependency 'crack', '~> 0.4'
+  s.add_dependency 'multipart-post', '~> 2.0'
 
   s.add_development_dependency 'rake', '~> 10.1'
   s.add_development_dependency 'webmock', '~> 1.21'


### PR DESCRIPTION
The Fogbugz API allows the inclusion of attachments in your request, using multipart forms. This library, however, doesn't support multipart forms. This PR adds attachment support to ruby-fogbugz.

Unfortunately, Net::HTTP::Post doesn't support multipart forms. Therefore, this PR uses the [multipart-post](https://github.com/nicksieger/multipart-post) gem to create a multipart request. This gem is only used for API requests with attachments. All other API requests still use Net::HTTP::Post.
