### PR TITLE
Added an option to specify a CA cert bundle for https FogBugz servers

### DIFF
--- a/lib/ruby_fogbugz/adapters/http/net_http.rb
+++ b/lib/ruby_fogbugz/adapters/http/net_http.rb
@@ -9,6 +9,7 @@ module Fogbugz
 
         def initialize(options = {})
           @root_url = options[:uri]
+          @ca_file = options[:ca_file]
         end
 
         def request(action, options)
@@ -22,7 +23,10 @@ module Fogbugz
           request.set_form_data(params)
 
           http = Net::HTTP.new(uri.host, uri.port)
-          http.use_ssl = @root_url.start_with? 'https'
+          if @root_url.start_with? 'https'
+            http.use_ssl = true
+            http.ca_file = @ca_file
+          end
 
           response = http.start { |h| h.request(request) }
           response.body

--- a/lib/ruby_fogbugz/interface.rb
+++ b/lib/ruby_fogbugz/interface.rb
@@ -10,7 +10,7 @@ module Fogbugz
 
       raise InitializationError, 'Must supply URI (e.g. https://fogbugz.company.com)' unless options[:uri]
       @token = options[:token] if options[:token]
-      @http = Fogbugz.adapter[:http].new(uri: options[:uri])
+      @http = Fogbugz.adapter[:http].new(uri: options[:uri], ca_file: options[:ca_file])
       @xml = Fogbugz.adapter[:xml]
     end
 

--- a/ruby-fogbugz.gemspec
+++ b/ruby-fogbugz.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.3'
   s.add_development_dependency 'codeclimate-test-reporter'
 
-  s.files         = `git ls-files`.split('\n')
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split('\n')
-  s.executables   = `git ls-files -- bin/*`.split('\n').map { |f| File.basename(f) }
+  s.files         = `git ls-files`.split("\n")
+  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 end


### PR DESCRIPTION
This pull request adds the ability to specify a root certificate authority file for use with https FogBugz servers.  The only way I was able to get ruby-fogbugz to work with an https fogbugz server (for example, the hosted FogBugz site) in a ruby environment where `OpenSSL::SSL::VERIFY_PEER` is the default for `Net::HTTP` https requests was to set the `SSL_CERT_FILE` environment variable to point to a CA bundle that had the correct certificates.  However, this approach is not always desirable.

I also fixed an issue in the gemspec.  The `\n` characters were surrounded by single quotes instead of double quotes, causing them to not be interpreted as newline characters and causing the gem to fail to build.
